### PR TITLE
Add version to async client and docfix

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+2.12.2 (2024-05-02)
+-------------------
+- Add .version() method to CybsiAsyncClient
+- Docfix of DictionaryItemForm and DictItemAttributeValue
+- Fix stored query filter
+
 2.12.1 (2024-04-26)
 -------------------
 - Fix api key generation

--- a/cybsi/__version__.py
+++ b/cybsi/__version__.py
@@ -1,4 +1,4 @@
-__version__ = "2.12.1"
+__version__ = "2.12.2"
 __title__ = "cybsi-python-sdk"
 __description__ = "Cybersecurity threat intelligence development kit"
 __license__ = "Apache License 2.0"

--- a/cybsi/api/client.py
+++ b/cybsi/api/client.py
@@ -275,6 +275,19 @@ class CybsiAsyncClient:
         """Observable API handle."""
         return ObservableAsyncAPI(self._connector)
 
+    async def version(self) -> "VersionView":
+        """Get API and server version information.
+
+        Note:
+            Calls `GET /version`.
+        Returns:
+            Version view.
+        """
+
+        path = "/version"
+        resp = await self._connector.do_get(path)
+        return VersionView(resp.json())
+
 
 class VersionView(JsonObjectView):
     """Version view."""

--- a/cybsi/api/dictionary/api.py
+++ b/cybsi/api/dictionary/api.py
@@ -360,8 +360,9 @@ class DictionaryItemForm(JsonObjectForm):
     Args:
         dictionary_uuid: Dictionary identifier.
         key: Dictionary item key. The key should consist of characters
-            according to the pattern `[a-zA-Z0-9_ -]` and
-            have length in the range `[1;30]`.
+            according to the pattern `[a-zA-Z0-9_ :.@-]` and
+            have length in the range `[1;50]`.
+            First and last char of key can't be space-symbol
             User-specified key case is preserved.
     """
 
@@ -377,8 +378,9 @@ class DictItemAttributeValue(JsonObjectForm):
 
     Args:
        key: Dictionary item key. The key should consist of characters
-            according to the pattern `[a-zA-Z0-9_ -]` and
-            have length in the range `[1;30]`.
+            according to the pattern `[a-zA-Z0-9_ :.@-]` and
+            have length in the range `[1;50]`.
+            First and last char of key can't be space-symbol
             User-specified key case is preserved.
     """
 

--- a/cybsi/api/search/__init__.py
+++ b/cybsi/api/search/__init__.py
@@ -10,6 +10,7 @@ from .stored_queries import (
     StoredQueryForm,
     StoredQueryValidationView,
     StoredQueryView,
+    StoredQueryFilterView,
     CybsiLangErrorView,
     ErrorPosition,
 )

--- a/cybsi/api/search/stored_queries.py
+++ b/cybsi/api/search/stored_queries.py
@@ -110,7 +110,7 @@ class StoredQueriesAPI(BaseAPI):
         user_uuid: Optional[uuid.UUID] = None,
         cursor: Optional[Cursor] = None,
         limit: Optional[int] = None,
-    ) -> Page["StoredQueryView"]:
+    ) -> Page["StoredQueryFilterView"]:
         """Get page of filtered stored queries list.
 
         Note:
@@ -138,7 +138,7 @@ class StoredQueriesAPI(BaseAPI):
             params["limit"] = str(limit)
 
         resp = self._connector.do_get(self._path, params=params)
-        page = Page(self._connector.do_get, resp, StoredQueryView)
+        page = Page(self._connector.do_get, resp, StoredQueryFilterView)
         return page
 
 
@@ -264,9 +264,9 @@ class StoredQueryCommonView(RefView):
         return self._get("name")
 
 
-class StoredQueryView(_TaggedRefView, StoredQueryCommonView):
-    """View of a stored query,
-    as retrieved by :meth:`StoredQueriesAPI.view`."""
+class StoredQueryFilterView(StoredQueryCommonView):
+    """Filter view of a stored query,
+    as retrieved by :meth:`StoredQueriesAPI.filter`."""
 
     @property
     def text(self) -> str:
@@ -279,3 +279,8 @@ class StoredQueryView(_TaggedRefView, StoredQueryCommonView):
         """User, author of the query."""
 
         return RefView(self._get("author"))
+
+
+class StoredQueryView(_TaggedRefView, StoredQueryFilterView):
+    """View of a stored query,
+    as retrieved by :meth:`StoredQueriesAPI.view`."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cybsi-sdk"
-version = "2.12.1"
+version = "2.12.2"
 description = "Cybsi development kit"
 authors = ["Cybsi SDK developers"]
 license = "Apache License 2.0"
@@ -42,7 +42,7 @@ extend_skip = ["__init__.py"]
 [tool.tbump]
 
 [tool.tbump.version]
-current = "2.12.1"
+current = "2.12.2"
 
 regex = '''
   ^


### PR DESCRIPTION
Для удобства работы с асинхронным клиентом добавил метод для проверки версии (сейчас приходится делать это через защищенное поле ._connector у объекта)

Поправил докстринги для DictItemAttributeValue и DictionaryItemForm, с 2.12 требования к ключам изменились