### PR TITLE
Fix stored query filter

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
 Release History
 ===============
 
+2.12.2 (2024-05-03)
+-------------------
+- Fix stored query filter
+
 2.12.1 (2024-04-26)
 -------------------
 - Fix api key generation

--- a/cybsi/__version__.py
+++ b/cybsi/__version__.py
@@ -1,4 +1,4 @@
-__version__ = "2.12.1"
+__version__ = "2.12.2"
 __title__ = "cybsi-python-sdk"
 __description__ = "Cybersecurity threat intelligence development kit"
 __license__ = "Apache License 2.0"

--- a/cybsi/api/search/__init__.py
+++ b/cybsi/api/search/__init__.py
@@ -10,6 +10,7 @@ from .stored_queries import (
     StoredQueryForm,
     StoredQueryValidationView,
     StoredQueryView,
+    StoredQueryFilterView,
     CybsiLangErrorView,
     ErrorPosition,
 )

--- a/cybsi/api/search/stored_queries.py
+++ b/cybsi/api/search/stored_queries.py
@@ -110,7 +110,7 @@ class StoredQueriesAPI(BaseAPI):
         user_uuid: Optional[uuid.UUID] = None,
         cursor: Optional[Cursor] = None,
         limit: Optional[int] = None,
-    ) -> Page["StoredQueryView"]:
+    ) -> Page["StoredQueryFilterView"]:
         """Get page of filtered stored queries list.
 
         Note:
@@ -138,7 +138,7 @@ class StoredQueriesAPI(BaseAPI):
             params["limit"] = str(limit)
 
         resp = self._connector.do_get(self._path, params=params)
-        page = Page(self._connector.do_get, resp, StoredQueryView)
+        page = Page(self._connector.do_get, resp, StoredQueryFilterView)
         return page
 
 
@@ -264,9 +264,9 @@ class StoredQueryCommonView(RefView):
         return self._get("name")
 
 
-class StoredQueryView(_TaggedRefView, StoredQueryCommonView):
-    """View of a stored query,
-    as retrieved by :meth:`StoredQueriesAPI.view`."""
+class StoredQueryFilterView(StoredQueryCommonView):
+    """Filter view of a stored query,
+    as retrieved by :meth:`StoredQueriesAPI.filter`."""
 
     @property
     def text(self) -> str:
@@ -279,3 +279,8 @@ class StoredQueryView(_TaggedRefView, StoredQueryCommonView):
         """User, author of the query."""
 
         return RefView(self._get("author"))
+
+
+class StoredQueryView(_TaggedRefView, StoredQueryFilterView):
+    """View of a stored query,
+    as retrieved by :meth:`StoredQueriesAPI.view`."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cybsi-sdk"
-version = "2.12.1"
+version = "2.12.2"
 description = "Cybsi development kit"
 authors = ["Cybsi SDK developers"]
 license = "Apache License 2.0"
@@ -42,7 +42,7 @@ extend_skip = ["__init__.py"]
 [tool.tbump]
 
 [tool.tbump.version]
-current = "2.12.1"
+current = "2.12.2"
 
 regex = '''
   ^


### PR DESCRIPTION
У нас совпадают вьюхи на просмотр поискового запроса и на получение списка таких запросов. 
Проблема была при запросе списка запросов. Там наследовался `_TaggedRefView`, что мешало распарсить страничку с результатами