### PR TITLE
Fix cgi module

### DIFF
--- a/.github/workflows/validate-branch.yaml
+++ b/.github/workflows/validate-branch.yaml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 Release History
 ===============
+
+2.14.2 (2025-04-01)
+---------------------
+- Replace cgi to email.message module
+
 2.14.1 (2024-11-21)
 ---------------------
 - Add IsDelegated and RegionalInternetRegistry attr types to converter

--- a/cybsi/__version__.py
+++ b/cybsi/__version__.py
@@ -1,4 +1,4 @@
-__version__ = "2.14.1"
+__version__ = "2.14.2"
 __title__ = "cybsi-python-sdk"
 __description__ = "Cybersecurity threat intelligence development kit"
 __license__ = "Apache License 2.0"

--- a/cybsi/api/artifact/api.py
+++ b/cybsi/api/artifact/api.py
@@ -1,7 +1,7 @@
-import cgi
 import uuid
 from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime
+from email.message import Message
 from io import BytesIO
 from typing import (
     Any,
@@ -537,14 +537,15 @@ class ArtifactAsyncContent:
 def _parse_content_filename(response) -> str:
     """Parse filename parameter from content-disposition header."""
     try:
-        value, params = cgi.parse_header(response.headers["content-disposition"])
+        msg = Message()
+        msg["content-disposition"] = response.headers["content-disposition"]
     except KeyError:
         raise CybsiError("Content-disposition header not found") from None
 
-    try:
-        return params["filename"]
-    except KeyError:
+    filename = msg.get_filename()
+    if filename is None:
         raise CybsiError("filename not found in Content-disposition header") from None
+    return filename
 
 
 class ArtifactCommonView(RefView):

--- a/cybsi/api/observable/aggregate_section.py
+++ b/cybsi/api/observable/aggregate_section.py
@@ -12,11 +12,11 @@ from .enums import (
     IdentityClass,
     NodeRole,
     PotentialDamage,
+    RegionalInternetRegistry,
     RelatedThreatCategory,
     ShareLevels,
     ThreatCategory,
     ThreatStatus,
-    RegionalInternetRegistry,
 )
 
 T = TypeVar("T")
@@ -58,7 +58,7 @@ def _convert_attribute_value_type(
         AttributeNames.Techniques: DictionaryItemCommonView,
         AttributeNames.Labels: DictionaryItemCommonView,
         AttributeNames.IsDelegated: bool,
-        AttributeNames.RegionalInternetRegistry: RegionalInternetRegistry
+        AttributeNames.RegionalInternetRegistry: RegionalInternetRegistry,
     }
 
     return _attribute_value_types[attribute_name](val)

--- a/cybsi/api/report/api.py
+++ b/cybsi/api/report/api.py
@@ -449,7 +449,7 @@ class ReportsAsyncAPI(BaseAsyncAPI):
         external_id: Optional[str] = None,
         cursor: Optional[Cursor] = None,
         limit: Optional[int] = None,
-        reverse_order: bool = False
+        reverse_order: bool = False,
     ) -> AsyncPage["ReportHeaderView"]:
         """Get report header filtration list that matches the specified criteria.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cybsi-sdk"
-version = "2.14.1"
+version = "2.14.2"
 description = "Cybsi development kit"
 authors = ["Cybsi SDK developers"]
 license = "Apache License 2.0"
@@ -42,7 +42,7 @@ extend_skip = ["__init__.py"]
 [tool.tbump]
 
 [tool.tbump.version]
-current = "2.14.1"
+current = "2.14.2"
 
 regex = '''
   ^


### PR DESCRIPTION
Обнаружил, при работе с python 3.13 у нас есть проблемный модуль cgi 
Используется в одном, единственном месте, при парсинге хедера  `content-disposition` у артефакта, для получения имени файла

Модуль начиная с 3.11 он помечен как депрекейтит, а в 3.13 удалён. В PEP рекомендуется использовать модуль `email.message` для  парсинга хедера https://peps.python.org/pep-0594/#cgi 
